### PR TITLE
Feature/ab#1507 add auth to import script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ webclient/src/main/app/yarn-error.log*
 
 webclient/src/main/app/package-lock.json
 test.log
+
+env.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,16 @@
 
 Changelog of ai-cockpit.
 
-## Current Version ()
+## 2 (2025-04-11)
 
 ### Features
 
 -  Support hierarchical object names for minio resources ([6ad91](https://github.com/starwit/ai-cockpit/commit/6ad91157c6616fd) flonix8)  
+-  ab#1479 add backend authentication for services (resource server pattern) ([80318](https://github.com/starwit/ai-cockpit/commit/8031814c645abd9) Anett Hübner)  
 
 ### Bug Fixes
 
 -  corrected errors because of new mui version ([f3900](https://github.com/starwit/ai-cockpit/commit/f3900919baf8523) Anett Hübner)  
-
-## 1 (2025-04-10)
-
-### Features
-
--  ab#1479 add backend authentication for services (resource server pattern) ([80318](https://github.com/starwit/ai-cockpit/commit/8031814c645abd9) Anett Hübner)  
 
 ## 1 (2025-03-19)
 

--- a/docs/README-DEV.MD
+++ b/docs/README-DEV.MD
@@ -147,15 +147,14 @@ File with demo data can contain marker __DATETIME__ as value for decision creati
 
 #### Timed decision import to local dev instances
 
-If you want to insert actual decisions you can use a script in folder experiment-setup. Please note, that demodata The following code snippet shows
+If you want to insert actual decisions you can use a script in folder experiment-setup. Please note, that these are just demodata - do not import them into productive instances. Import script can be used as follows:
 example usage:
 
   ```bash
     cd experiment-setup
-    ./fillDatabaseScript.sh http://localhost:8081/ai-cockpit/api/ /path/to/binaries/ /path/to/demodata/demodata.json 5
+    ./fillDatabaseScript.sh
   ```
-
-Params are dev instance location (no auth), binary data (e.g. videos), file with data to import and duration between inserts. Please note, that this will work only in a local development setup without authentication.
+Please note, that this script expects an _env.sh_ file in the same folder. Content can be derived from [template](../experiment-setup/env.sh.template).
 
 This script also allows you, to test how decisions are flowing into AI Cockpit. __Note__: you will
 have to prepare video data on a Minio instance.
@@ -229,7 +228,7 @@ docker compose up
 
 In order to test you need to setup a Keycloak instance and there a client needs to be configured like so:
 
-![Keycloak](docs/imgs/keycloak-config.png)
+![Keycloak](imgs/keycloak-config.png)
 
 Adjust and add the following entries to your local application property file. Replace coordinates according to your Keycloak configuration and use spring profile `SPRING_PROFILES_ACTIVE=auth`
 
@@ -255,14 +254,14 @@ Once security configuration is correct, you can access application API by reques
 curl -H application/x-www-form-urlencoded -d "realm=default" -d "client_id=client_id" -d "username=name" -d "password=password" -d "grant_type=password" "http://hostname/realms/ai-cockpit/protocol/openid-connect/token"
 ```
 
-for local setup, you can use the following:
+If you want to extract token as variable, the following code does that:
 
 ```bash
-curl -H application/x-www-form-urlencoded -d "realm=default" -d "client_id=client_id" -d "username=admin" -d "password=admin" -d "grant_type=password" "http://hostname/auth/realms/ai-cockpit/protocol/openid-connect/token | jq"
+TOKEN=`curl -H application/x-www-form-urlencoded -d "realm=default" -d "client_id=client_id" -d "username=admin" -d "password=admin" -d "grant_type=password" "http://hostname/auth/realms/ai-cockpit/protocol/openid-connect/token | jq -r '.access_token'`"
 ```
 
 Response will like so:
-![Token Response](docs/imgs/auth_token_response.png)
+![Token Response](imgs/auth_token_response.png)
 
 Copy content of field _access_token_ into a environment variable like so:
 

--- a/experiment-setup/env.sh.template
+++ b/experiment-setup/env.sh.template
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+INTERVAL=10  # post intervall
+URL_BASE="http://localhost:8081/ai-cockpit/api/"
+URL_DECISIONS=$URL_BASE"/decision"
+SCENARIO="traffic"
+LANGUAGE="en"
+JSON_FILE=data_structures/$SCENARIO-$LANGUAGE/demodata.json
+
+# coordinates to get access token
+AUTH=true
+AUTH_URL=http://hostname/realms/aicockpit/protocol/openid-connect/token
+USERNAME=username
+PASSWORD=password
+
+# coordinates to import binary data
+IMPORT_BINARY_DATA=false
+BINARY_DATA=binary_data/$SCENARIO
+MINIO_LOCATION=http://localhost:9000
+MINIO_USER=user
+MINIO_PASSWORD=password

--- a/experiment-setup/fillDatabaseScript.sh
+++ b/experiment-setup/fillDatabaseScript.sh
@@ -26,7 +26,7 @@ function main {
 get_access_token() {
     # get access token
     echo "Getting access token from " $AUTH_URL
-    ACCESS_TOKEN=`curl -X POST  -d "realm=default" -d "client_id=aicockpit" -d "username=$USERNAME" -d "password=$PASSWORD" -d "grant_type=password" $AUTH_URL | jq -r '.access_token'`
+    ACCESS_TOKEN=`curl -X POST -d "realm=aicockpit" -d "client_id=aicockpit" -d "username=$USERNAME" -d "password=$PASSWORD" -d "grant_type=password" $AUTH_URL | jq -r '.access_token'`
 }
 
 upload_binary_data() {

--- a/experiment-setup/fillDatabaseScript.sh
+++ b/experiment-setup/fillDatabaseScript.sh
@@ -1,61 +1,53 @@
 #!/bin/bash
 
-# default values, taking data from repo
-INTERVAL=10  # post intervall
-URL_BASE="http://localhost:8081/ai-cockpit/api/"
-URL_DECISIONS=$URL_BASE"decision"
-SCENARIO="traffic"
-LANGUAGE="en"
-JSON_FILE=data_structures/$SCENARIO-$LANGUAGE/demodata.json
-BINARY_DATA=""
+if [ ! -f ./env.sh ]; then
+    echo "Config file not found - Exit"
+    exit 1
+fi
+
+source ./env.sh
+
 
 function main {
-    if [ -n "$1" ]; then
-        echo "Param for target Base URL exists " $1
-        URL_BASE=$1
-        URL_DECISIONS=$URL_BASE"/decision"
+    if $IMPORT_BINARY_DATA
+    then
+        echo "Binary data will be uploaded to minio"
+        upload_binary_data
     fi
 
-    BINARY_DATA=binary_data/$SCENARIO
-    if [ -n "$2" ]; then
-        echo "Param for binary exists " $2
-        BINARY_DATA=$2
-    fi  
-    
-    if [ -n "$3" ]; then
-        echo "Param for scenario data exists " $3
-        JSON_FILE=$3
-    fi   
-
-    if [ -n "$4" ]; then
-        echo "Param for insert interval exists " $4
-        INTERVAL=$4
+    if $AUTH
+    then
+        get_access_token
     fi
 
-    upload_binary_data
     import_incidents
+}
+
+get_access_token() {
+    # get access token
+    echo "Getting access token from " $AUTH_URL
+    ACCESS_TOKEN=`curl -X POST  -d "realm=default" -d "client_id=aicockpit" -d "username=$USERNAME" -d "password=$PASSWORD" -d "grant_type=password" $AUTH_URL | jq -r '.access_token'`
 }
 
 upload_binary_data() {
     echo "Importing binary data from $BINARY_DATA"
 
-    mc alias set myminio http://localhost:9000 minioadmin minioadmin;
+    mc alias set myminio $MINIO_LOCATION $MINIO_USER $MINIO_PASSWORD;
     mc mb -p myminio/anomalies
     mc ls myminio
     mc policy set public myminio/anomalies
-    ls -al binary_data/$SCENARIO/
-    mc cp --recursive binary_data/$SCENARIO/* myminio/anomalies
+    ls -al $BINARY_DATA
+    mc cp --recursive BINARY_DATA/* myminio/anomalies
 }
 
 import_incidents() {
-    echo "starte inserting data to " $URL_DECISIONS " from input file " $JSON_FILE " with intervall " $INTERVAL
+    echo "start inserting data to " $URL_DECISIONS " from input file " $JSON_FILE " with intervall " $INTERVAL
     # capture data from json file and send to ai cockpit
     jq -c '.[]' "$JSON_FILE" | while read -r obj; do
-        # setting insert datetime
         insert_datetime=$(date '+%Y-%m-%dT%H:%M:%SZ')
         obj=$(echo "${obj/DATETIME/"$insert_datetime"}")
         echo $obj
-        curl -X POST -H "Content-Type: application/json" -d "$obj" "$URL_DECISIONS"
+        curl -X POST -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" -d "$obj" "$URL_DECISIONS"
         sleep "$INTERVAL"
     done
 }


### PR DESCRIPTION
Auth script now takes credentials from env-file and authenticates against identity provider.

## Motivation and Context
Cockpit instances can (and should) be protected by authentication against an identity provider. Import script now takes this into account.

## How has this been tested?
Import to local dev env & staging instances

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
